### PR TITLE
Implement MCVID auth state.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,9 @@
 
+0.0.4 / 2020-10-10
+==================
+
+  * Add an additional parameter to syncIntegrationCode to define the authentication state of the user.
+
 0.0.3 / 2019-07-03
 ==================
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.middlewares
 
-VERSION=0.0.3
+VERSION=0.0.4
 
 POM_ARTIFACT_ID=mcvid
 POM_PACKAGING=jar

--- a/src/main/java/com/segment/analytics/android/middlewares/mcvid/MCVIDAuthState.java
+++ b/src/main/java/com/segment/analytics/android/middlewares/mcvid/MCVIDAuthState.java
@@ -1,0 +1,34 @@
+package com.segment.analytics.android.middlewares.mcvid;
+
+/**
+ * Visitor Authentication States in Audience Manager.
+ *
+ * @see "https://docs.adobe.com/content/help/en/id-service/using/reference/authenticated-state.html"
+ */
+public enum MCVIDAuthState {
+  // Unknown or never authenticated.
+  MCVIDAuthStateUnknown(0),
+
+  // Authenticated for a particular instance, page, or app.
+  MCVIDAuthStateAuthenticated(1),
+
+  // Logged out.
+  MCVIDAuthStateLoggedOut(2);
+
+  private final int state;
+
+  MCVIDAuthState(int state) {
+    this.state = state;
+  }
+
+  public int getState() {
+    return state;
+  }
+
+  @Override
+  public String toString() {
+    return "MCVIDAuthState{" +
+        "state=" + state +
+        '}';
+  }
+}

--- a/src/main/java/com/segment/analytics/android/middlewares/mcvid/MarketingCloudClient.java
+++ b/src/main/java/com/segment/analytics/android/middlewares/mcvid/MarketingCloudClient.java
@@ -12,6 +12,7 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -37,7 +38,8 @@ public interface MarketingCloudClient {
      * @throws MarketingCloudException if the response from the service is unexpected
      * @throws IOException if an I/O exception occurs
      */
-    public void idSync(String visitorId, String integrationCode, String customerId) throws MarketingCloudException, IOException;
+    public void idSync(String visitorId, String integrationCode, String customerId, MCVIDAuthState authentication)
+        throws MarketingCloudException, IOException;
 
     /**
      * Represents any unexpected response from the Marketing Cloud service. Usually anything that is not a 200
@@ -94,6 +96,7 @@ public interface MarketingCloudClient {
         private final static String CUSTOMER_ID_FIELD = "d_cid_ic";
         private final static String CHARSET = "UTF-8";
         private final static String RESPONSE_CHARSET = "application/json;charset=utf-8";
+        private static final String SEPARATOR = "%%01";
 
         private String organizationId;
         private int region;
@@ -115,10 +118,12 @@ public interface MarketingCloudClient {
         }
 
         @Override
-        public void idSync(String visitorId, String integrationCode, String customerId) throws MarketingCloudException, IOException {
+        public void idSync(String visitorId, String integrationCode, String customerId, MCVIDAuthState authentication)
+            throws MarketingCloudException, IOException {
             Map<String, String> parameters = new HashMap<>();
             parameters.put(VID_FIELD, visitorId);
-            parameters.put(CUSTOMER_ID_FIELD, String.format("%s%%01%s", integrationCode, customerId));
+            parameters.put(CUSTOMER_ID_FIELD, String.format(Locale.US, "%s" + SEPARATOR + "%s" + SEPARATOR + "%d",
+                integrationCode, customerId, authentication.getState()));
 
             URL url = createUrl(parameters);
             sendRequest(url);

--- a/src/main/java/com/segment/analytics/android/middlewares/mcvid/VisitorIdManager.java
+++ b/src/main/java/com/segment/analytics/android/middlewares/mcvid/VisitorIdManager.java
@@ -176,7 +176,8 @@ public interface VisitorIdManager {
                     }
 
                     try {
-                        client.idSync(visitorId, ANDROID_INTEGRATION_CODE, advertisingId);
+                        // According to Adobe, Unknown is applied by default when AuthState is not used with a visitor ID or not explicitly set on each page or app context.
+                        client.idSync(visitorId, ANDROID_INTEGRATION_CODE, advertisingId, MCVIDAuthState.MCVIDAuthStateUnknown);
                     } catch (MarketingCloudClient.MarketingCloudException e) {
                         handleError("Error syncing visitor ID and advertising ID: %s", e);
                         if (e.isBadInput()) {

--- a/src/test/java/com/segment/analytics/android/middlewares/mcvid/MarketingCloudClientTest.java
+++ b/src/test/java/com/segment/analytics/android/middlewares/mcvid/MarketingCloudClientTest.java
@@ -2,6 +2,7 @@ package com.segment.analytics.android.middlewares.mcvid;
 
 import android.net.Uri;
 
+import java.util.ArrayList;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -63,21 +64,27 @@ public class MarketingCloudClientTest {
     public void idSync() throws MarketingCloudClient.MarketingCloudException, IOException {
         String visitorId = client.getVisitorID();
         final String expectedUrl = String.format("https://dpm.demdex.net/id?d_mid=%s&d_ver=2&dcs_region=%d&d_orgid=%s&d_rtbd=json&d_cid_ic=%s%%01%s", visitorId, region, organizationId, DEFAULT_INTEGRATION_CODE, customerId);
+        final Map<MCVIDAuthState, String> expectedUrlsWithAuthState = new HashMap<>();
+        expectedUrlsWithAuthState.put(MCVIDAuthState.MCVIDAuthStateUnknown, expectedUrl + "%01" + MCVIDAuthState.MCVIDAuthStateUnknown.getState());
+        expectedUrlsWithAuthState.put(MCVIDAuthState.MCVIDAuthStateAuthenticated, expectedUrl + "%01" + MCVIDAuthState.MCVIDAuthStateAuthenticated.getState());
+        expectedUrlsWithAuthState.put(MCVIDAuthState.MCVIDAuthStateLoggedOut, expectedUrl + "%01" + MCVIDAuthState.MCVIDAuthStateLoggedOut.getState());
 
         MarketingCloudClient.HttpClient spy = Mockito.spy(client);
-        spy.idSync(visitorId, DEFAULT_INTEGRATION_CODE, customerId);
-        Mockito.verify(spy, Mockito.times(1)).sendRequest(Mockito.argThat(new ArgumentMatcher<URL>() {
-            @Override
-            public boolean matches(URL argument) {
-                return expectedUrl.equals(argument.toString());
-            }
-        }));
+        for (final MCVIDAuthState authState : expectedUrlsWithAuthState.keySet()) {
+            spy.idSync(visitorId, DEFAULT_INTEGRATION_CODE, customerId, authState);
+            Mockito.verify(spy, Mockito.times(1)).sendRequest(Mockito.argThat(new ArgumentMatcher<URL>() {
+                @Override
+                public boolean matches(URL argument) {
+                    return expectedUrlsWithAuthState.get(authState).equals(argument.toString());
+                }
+            }));
+        }
     }
 
     @Test(expected = MarketingCloudClient.MarketingCloudException.class)
     public void idSync_invalidVisitorId() throws MarketingCloudClient.MarketingCloudException, IOException {
         String vid = "this is invalid big time";
-        client.idSync(vid, DEFAULT_INTEGRATION_CODE, customerId);
+        client.idSync(vid, DEFAULT_INTEGRATION_CODE, customerId, MCVIDAuthState.MCVIDAuthStateUnknown);
     }
 
     @Test
@@ -122,7 +129,6 @@ public class MarketingCloudClientTest {
 
     @Test
     public void createVisitorIdUrl() {
-
         String builtUrl = client.createUrl(new HashMap<String, String>()).toString();
         String expectedUrl = String.format("https://dpm.demdex.net/id?d_ver=2&dcs_region=%d&d_orgid=%s&d_rtbd=json", region, organizationId);
         Assert.assertEquals(expectedUrl, builtUrl);
@@ -137,20 +143,21 @@ public class MarketingCloudClientTest {
 
     @Test
     public void idSyncUrl() {
-
         Map<String, String> parameters = new HashMap<>();
         parameters.put("d_mid", "visitorId");
-        parameters.put("d_cid_ic", customerId);
+        parameters.put("d_cid_ic", customerId + "%01" + MCVIDAuthState.MCVIDAuthStateUnknown.getState());
 
         String builtUrl = client.createUrl(parameters).toString();
-        String expectedUrl = String.format("https://dpm.demdex.net/id?d_mid=visitorId&d_ver=2&dcs_region=%d&d_orgid=%s&d_rtbd=json&d_cid_ic=%s", region, organizationId, customerId);
+        String expectedUrl = String.format("https://dpm.demdex.net/id?d_mid=visitorId&d_ver=2&dcs_region=%d&d_orgid=%s&d_rtbd=json&d_cid_ic=%s%%01%d", region, organizationId, customerId,
+            MCVIDAuthState.MCVIDAuthStateUnknown.getState());
         Assert.assertEquals(expectedUrl, builtUrl);
 
         Uri uri = Uri.parse(builtUrl);
         Assert.assertEquals("https", uri.getScheme());
         Assert.assertEquals("dpm.demdex.net", uri.getAuthority());
         Assert.assertEquals("/id", uri.getPath());
-        String expectedQuery = String.format("d_mid=visitorId&d_ver=2&dcs_region=%d&d_orgid=%s&d_rtbd=json&d_cid_ic=%s", region, organizationId, customerId);
+        String expectedQuery = String.format("d_mid=visitorId&d_ver=2&dcs_region=%d&d_orgid=%s&d_rtbd=json&d_cid_ic=%s%%01%d", region, organizationId, customerId,
+            MCVIDAuthState.MCVIDAuthStateUnknown.getState());
         Assert.assertEquals(expectedQuery, uri.getEncodedQuery());
     }
 

--- a/src/test/java/com/segment/analytics/android/middlewares/mcvid/VisitorIdManagerTest.java
+++ b/src/test/java/com/segment/analytics/android/middlewares/mcvid/VisitorIdManagerTest.java
@@ -225,7 +225,7 @@ public class VisitorIdManagerTest {
         String visitorId = "visitorId";
         String advertisingId = "advertisingId";
         Mockito.when(client.getVisitorID()).thenReturn(visitorId);
-        Mockito.doThrow(new MarketingCloudClient.MarketingCloudException("Error!")).when(client).idSync(visitorId, "DSID_20914", advertisingId);
+        Mockito.doThrow(new MarketingCloudClient.MarketingCloudException("Error!")).when(client).idSync(visitorId, "DSID_20914", advertisingId, MCVIDAuthState.MCVIDAuthStateUnknown);
         Mockito.when(store.getSyncedAdvertisingId()).thenReturn(advertisingId);
 
 


### PR DESCRIPTION
**What does this PR do?**

PR originally submitted as https://github.com/segmentio/analytics-android-mcvid/pull/4 by @ggm. Thank you!

> For some segmentation features to properly work in Adobe Audience Manager we need to set the authenticated state of our users. As far as we know this is not needed for the standard id-sync call performed with the advertising identifier, but that's not the case for our own use of `syncIntegrationCode` as we use it for identifying logged in users.
> 
> For this reason I've added an additional parameter to `syncIntegrationCode` to define the authentication state of the user.
> 
> * [Visitor Auth States in Audience Manager](https://docs.adobe.com/content/help/en/audience-manager/user-guide/reference/visitor-authentication-states.html)
> 
> ⚠️ Most of the changes in this PR are just the aftermath of invoking `pod install`, I've added less than 40 lines of code without any breaking change on the public API 😄 


**Are there breaking changes in this PR?**

No


**What are the relevant tickets?**

https://segment.atlassian.net/browse/STRATCONN-254
